### PR TITLE
fix(security): disable Discord mentions in bot output (#274)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ A small Discord ↔ OpenCode (`opencode`) bridge that runs locally.
 - **Slash commands = escape hatch / control plane**
   - The bridge registers a single `/oc` command with subcommands to inspect and control mappings.
 
+## Security posture
+
+- **No accidental pings from bot output**: all bot message sends/edits set `allowedMentions` to an explicit empty config (`parse: []`, `users: []`, `roles: []`).
+  - This prevents relayed OpenCode output like `@everyone`, `@here`, or `<@roleId>` from generating notifications.
+
 ## Requirements
 
 - Node.js 22+

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ A small Discord ↔ OpenCode (`opencode`) bridge that runs locally.
 
 - **No accidental pings from bot output**: all bot message sends/edits set `allowedMentions` to an explicit empty config (`parse: []`, `users: []`, `roles: []`).
   - This prevents relayed OpenCode output like `@everyone`, `@here`, or `<@roleId>` from generating notifications.
+- **Manual verification**: when the bridge is running, have an OpenCode session print `@everyone` (e.g., `print('@everyone ping test')`). The Discord thread should show the literal text without highlighting or pinging anyone. This manual check is the acceptance criterion for issue #274.
+
 
 ## Requirements
 

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -12,6 +12,7 @@ import {
   ThreadChannel,
 } from 'discord.js';
 import type { Config } from './config.js';
+import { ALLOWED_MENTIONS_NONE } from './discordMentions.js';
 
 export type SlashHandlers = {
   status: (ix: ChatInputCommandInteraction) => Promise<void>;
@@ -24,6 +25,10 @@ export type SlashHandlers = {
 
 export function createDiscordClient(cfg: Config): Client {
   return new Client({
+    // Security hardening (issue #274): ensure bot output never triggers pings.
+    // We also enforce this at call sites (safeReply/safeEdit/ix* helpers), but
+    // setting it here provides a global default.
+    allowedMentions: ALLOWED_MENTIONS_NONE,
     intents: [
       GatewayIntentBits.Guilds,
       GatewayIntentBits.GuildMessages,

--- a/src/discordMentions.ts
+++ b/src/discordMentions.ts
@@ -1,0 +1,49 @@
+import type {
+  AllowedMentionsTypes,
+  InteractionEditReplyOptions,
+  InteractionReplyOptions,
+} from 'discord.js';
+
+// Security hardening: never allow bot output to create pings.
+// See issue #274.
+export const ALLOWED_MENTIONS_NONE: {
+  parse: AllowedMentionsTypes[];
+  users: string[];
+  roles: string[];
+} = {
+  parse: [],
+  users: [],
+  roles: [],
+};
+
+export function withNoMentions<T extends Record<string, any>>(opts: T): T {
+  return { ...opts, allowedMentions: ALLOWED_MENTIONS_NONE };
+}
+
+export function contentNoMentions(content: string, extra?: Record<string, any>): Record<string, any> {
+  return withNoMentions({ ...(extra ?? {}), content });
+}
+
+export async function safeReply(
+  msg: { reply: (opts: any) => Promise<any> },
+  content: string,
+  extra?: Record<string, any>,
+): Promise<any> {
+  return msg.reply(contentNoMentions(content, extra));
+}
+
+export async function safeEdit(
+  message: { edit: (opts: any) => Promise<any> },
+  content: string,
+  extra?: Record<string, any>,
+): Promise<any> {
+  return message.edit(contentNoMentions(content, extra));
+}
+
+export function ixReplyNoMentions(opts: InteractionReplyOptions): InteractionReplyOptions {
+  return withNoMentions(opts) as InteractionReplyOptions;
+}
+
+export function ixEditReplyNoMentions(opts: InteractionEditReplyOptions): InteractionEditReplyOptions {
+  return withNoMentions(opts) as InteractionEditReplyOptions;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ const FILE_PAUSED = 'pausedChannels.json';
 import { buildTopicWithCwd, isMainThreadName, parseCwdFromTopic } from './topic.js';
 import { hintMissingPermissionForSetTopic, runDiscordPreflightOnce } from './permissions.js';
 import { redactSecrets } from './redact.js';
+import { ixEditReplyNoMentions, ixReplyNoMentions, safeEdit, safeReply } from './discordMentions.js';
 
 type LogCtx = {
   corr?: string;
@@ -430,7 +431,7 @@ async function streamToDiscord(
   msg: Message,
   onChunk: (cb: (t: string) => void) => Promise<void>,
 ): Promise<void> {
-  const placeholder = await withDiscordRetry(() => msg.reply('…'), { phase: 'reply_placeholder' });
+  const placeholder = await withDiscordRetry(() => safeReply(msg, '…'), { phase: 'reply_placeholder' });
   let text = '';
   let lastEdit = 0;
 
@@ -460,19 +461,19 @@ async function streamToDiscord(
 
     await serial(async () => {
       if (safeText.length <= 2000) {
-        await withDiscordRetry(() => placeholder.edit(safeText || ''), { phase: 'edit_placeholder' });
+        await withDiscordRetry(() => safeEdit(placeholder, safeText || ''), { phase: 'edit_placeholder' });
         return;
       }
 
       // If too long, finalize current message and continue in new replies.
       // Keep the placeholder capped at 2000.
       const head = safeText.slice(0, 2000);
-      await withDiscordRetry(() => placeholder.edit(head), { phase: 'edit_placeholder_head' });
+      await withDiscordRetry(() => safeEdit(placeholder, head), { phase: 'edit_placeholder_head' });
       let rest = safeText.slice(2000);
       while (rest.length > 0) {
         const part = rest.slice(0, 2000);
         // eslint-disable-next-line no-await-in-loop
-        await withDiscordRetry(() => msg.reply(part), { phase: 'reply_continuation' });
+        await withDiscordRetry(() => safeReply(msg, part), { phase: 'reply_continuation' });
         rest = rest.slice(2000);
       }
     });
@@ -552,11 +553,13 @@ async function main() {
       if (ix.isChatInputCommand() && ix.commandName === 'oc') {
         const roleIds = extractRoleIdsFromInteractionMember(ix.member);
         if (!isAuthorizedForOcSlash(cfg, ix.user.id, roleIds)) {
-          await ix.reply({
-            content:
-              'Unauthorized: /oc is restricted in this server. Ask an admin to add your Discord user ID to DISCORD_ALLOW_USER_IDS (preferred) or add an allowed role ID to DISCORD_ALLOW_ROLE_IDS.',
-            ephemeral: true,
-          });
+          await ix.reply(
+            ixReplyNoMentions({
+              content:
+                'Unauthorized: /oc is restricted in this server. Ask an admin to add your Discord user ID to DISCORD_ALLOW_USER_IDS (preferred) or add an allowed role ID to DISCORD_ALLOW_ROLE_IDS.',
+              ephemeral: true,
+            }),
+          );
           return;
         }
       }
@@ -571,7 +574,13 @@ async function main() {
         status: async (cix: ChatInputCommandInteraction) => {
           const ch = cix.channel;
           const { thread, parent } = getThreadAndParentChannel(ch);
-          if (!parent) return void cix.reply({ content: 'Not a text channel/thread', ephemeral: true });
+          if (!parent)
+            return void cix.reply(
+              ixReplyNoMentions({
+                content: 'Not a text channel/thread',
+                ephemeral: true,
+              }),
+            );
           const topicCwd = parseCwdFromTopic(parent.topic);
           const topicCwdValidation = topicCwd ? await validateChannelCwd(cfg, topicCwd) : null;
 
@@ -590,21 +599,34 @@ async function main() {
             lines.push(`topic CWD ignored: ${formatCwdValidationError(topicCwdValidation)}`);
           }
 
-          await cix.reply({
-            content: lines.join('\n'),
-            ephemeral: true,
-          });
+          await cix.reply(
+            ixReplyNoMentions({
+              content: lines.join('\n'),
+              ephemeral: true,
+            }),
+          );
         },
         newSession: async (cix) => {
           const ch = cix.channel;
           const { thread, parent } = getThreadAndParentChannel(ch);
-          if (!thread || !parent) return void cix.reply({ content: 'Run this inside a thread', ephemeral: true });
+          if (!thread || !parent)
+            return void cix.reply(
+              ixReplyNoMentions({
+                content: 'Run this inside a thread',
+                ephemeral: true,
+              }),
+            );
 
           // Must ACK interactions quickly, otherwise Discord shows "该应用程序未响应".
           await cix.deferReply({ ephemeral: true });
 
           const cwd = await getChannelCwd(parent.id, parent.topic);
-          if (!cwd) return void cix.editReply({ content: 'No CWD configured for this channel' });
+          if (!cwd)
+            return void cix.editReply(
+              ixEditReplyNoMentions({
+                content: 'No CWD configured for this channel',
+              }),
+            );
 
           const meta = { corr, channelId: parent.id, threadId: thread.id };
 
@@ -624,18 +646,33 @@ async function main() {
 
           const now = Date.now();
           await setThreadBinding(thread.id, { sessionId: res.sessionId, cwd, createdAt: now, updatedAt: now });
-          await cix.editReply({ content: `Bound thread to NEW session: ${res.sessionId}` });
+          await cix.editReply(
+            ixEditReplyNoMentions({
+              content: `Bound thread to NEW session: ${res.sessionId}`,
+            }),
+          );
         },
         switchSession: async (cix) => {
           const ch = cix.channel;
           const { thread, parent } = getThreadAndParentChannel(ch);
-          if (!thread || !parent) return void cix.reply({ content: 'Run this inside a thread', ephemeral: true });
+          if (!thread || !parent)
+            return void cix.reply(
+              ixReplyNoMentions({
+                content: 'Run this inside a thread',
+                ephemeral: true,
+              }),
+            );
 
           await cix.deferReply({ ephemeral: true });
 
           const sessionId = cix.options.getString('session_id', true);
           const cwd = await getChannelCwd(parent.id, parent.topic);
-          if (!cwd) return void cix.editReply({ content: 'No CWD configured for this channel' });
+          if (!cwd)
+            return void cix.editReply(
+              ixEditReplyNoMentions({
+                content: 'No CWD configured for this channel',
+              }),
+            );
 
           const meta = { corr, channelId: parent.id, threadId: thread.id, sessionId };
 
@@ -655,28 +692,58 @@ async function main() {
 
           const now = Date.now();
           await setThreadBinding(thread.id, { sessionId, cwd, createdAt: now, updatedAt: now });
-          await cix.editReply({ content: `Bound thread to session: ${sessionId}` });
+          await cix.editReply(
+            ixEditReplyNoMentions({
+              content: `Bound thread to session: ${sessionId}`,
+            }),
+          );
         },
         pause: async (cix) => {
           const ch = cix.channel;
           const { parent } = getThreadAndParentChannel(ch);
-          if (!parent) return void cix.reply({ content: 'Not a text channel/thread', ephemeral: true });
+          if (!parent)
+            return void cix.reply(
+              ixReplyNoMentions({
+                content: 'Not a text channel/thread',
+                ephemeral: true,
+              }),
+            );
           await cix.deferReply({ ephemeral: true });
           await setChannelPaused(parent.id, true);
-          await cix.editReply({ content: 'Paused forwarding in this channel' });
+          await cix.editReply(
+            ixEditReplyNoMentions({
+              content: 'Paused forwarding in this channel',
+            }),
+          );
         },
         resume: async (cix) => {
           const ch = cix.channel;
           const { parent } = getThreadAndParentChannel(ch);
-          if (!parent) return void cix.reply({ content: 'Not a text channel/thread', ephemeral: true });
+          if (!parent)
+            return void cix.reply(
+              ixReplyNoMentions({
+                content: 'Not a text channel/thread',
+                ephemeral: true,
+              }),
+            );
           await cix.deferReply({ ephemeral: true });
           await setChannelPaused(parent.id, false);
-          await cix.editReply({ content: 'Resumed forwarding in this channel' });
+          await cix.editReply(
+            ixEditReplyNoMentions({
+              content: 'Resumed forwarding in this channel',
+            }),
+          );
         },
         cwdSet: async (cix) => {
           const ch = cix.channel;
           const { parent } = getThreadAndParentChannel(ch);
-          if (!parent) return void cix.reply({ content: 'Not a text channel/thread', ephemeral: true });
+          if (!parent)
+            return void cix.reply(
+              ixReplyNoMentions({
+                content: 'Not a text channel/thread',
+                ephemeral: true,
+              }),
+            );
 
           // Must ACK interactions quickly, otherwise Discord shows "该应用程序未响应".
           await cix.deferReply({ ephemeral: true });
@@ -684,9 +751,11 @@ async function main() {
           const cwd = cix.options.getString('path', true);
           const v = await validateChannelCwd(cfg, cwd);
           if (!v.ok) {
-            return void cix.editReply({
-              content: `Rejected CWD: ${formatCwdValidationError(v)}. (Tip: configure DISCORD_ALLOWED_CWD_PREFIXES to restrict allowed roots)`,
-            });
+            return void cix.editReply(
+              ixEditReplyNoMentions({
+                content: `Rejected CWD: ${formatCwdValidationError(v)}. (Tip: configure DISCORD_ALLOWED_CWD_PREFIXES to restrict allowed roots)`,
+              }),
+            );
           }
 
           await upsertChannelCwd(parent.id, v.cwd);
@@ -705,11 +774,13 @@ async function main() {
             }
           });
 
-          await cix.editReply({
-            content: topicOk
-              ? `Set CWD for channel to: ${v.cwd} (topic updated)`
-              : `Set CWD for channel to: ${v.cwd} (WARNING: failed to update channel topic; required permission: ${topicHint ?? 'Manage Channels'})`,
-          });
+          await cix.editReply(
+            ixEditReplyNoMentions({
+              content: topicOk
+                ? `Set CWD for channel to: ${v.cwd} (topic updated)`
+                : `Set CWD for channel to: ${v.cwd} (WARNING: failed to update channel topic; required permission: ${topicHint ?? 'Manage Channels'})`,
+            }),
+          );
         },
       });
     } catch (e: any) {
@@ -721,10 +792,19 @@ async function main() {
           // @ts-ignore
           if (ix.deferred || ix.replied) {
             // @ts-ignore
-            await ix.editReply({ content: `Error: ${e?.message ?? String(e)}` });
+            await ix.editReply(
+              ixEditReplyNoMentions({
+                content: `Error: ${e?.message ?? String(e)}`,
+              }),
+            );
           } else {
             // @ts-ignore
-            await ix.reply({ content: `Error: ${e?.message ?? String(e)}`, ephemeral: true });
+            await ix.reply(
+              ixReplyNoMentions({
+                content: `Error: ${e?.message ?? String(e)}`,
+                ephemeral: true,
+              }),
+            );
           }
         }
       } catch {}

--- a/test/discordMentions.test.js
+++ b/test/discordMentions.test.js
@@ -9,6 +9,7 @@ import {
   safeEdit,
   safeReply,
 } from '../dist/discordMentions.js';
+import { createDiscordClient } from '../dist/discord.js';
 
 test('contentNoMentions: forces allowedMentions parse/users/roles empty', () => {
   const opts = contentNoMentions('hi', { ephemeral: true, allowedMentions: { parse: ['users'] } });
@@ -53,4 +54,9 @@ test('ixReplyNoMentions/ixEditReplyNoMentions: force allowedMentions disabled', 
 
   const e = ixEditReplyNoMentions({ content: 'y', allowedMentions: { parse: ['roles'] } });
   assert.deepEqual(e.allowedMentions, ALLOWED_MENTIONS_NONE);
+});
+
+test('createDiscordClient: sets global default allowedMentions disabled', () => {
+  const client = createDiscordClient({});
+  assert.deepEqual(client.options.allowedMentions, ALLOWED_MENTIONS_NONE);
 });

--- a/test/discordMentions.test.js
+++ b/test/discordMentions.test.js
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  ALLOWED_MENTIONS_NONE,
+  contentNoMentions,
+  ixEditReplyNoMentions,
+  ixReplyNoMentions,
+  safeEdit,
+  safeReply,
+} from '../dist/discordMentions.js';
+
+test('contentNoMentions: forces allowedMentions parse/users/roles empty', () => {
+  const opts = contentNoMentions('hi', { ephemeral: true, allowedMentions: { parse: ['users'] } });
+  assert.equal(opts.content, 'hi');
+  assert.equal(opts.ephemeral, true);
+  assert.deepEqual(opts.allowedMentions, ALLOWED_MENTIONS_NONE);
+});
+
+test('safeReply: calls reply() with allowedMentions disabled', async () => {
+  const calls = [];
+  const msg = {
+    async reply(o) {
+      calls.push(o);
+      return { id: 'm1' };
+    },
+  };
+
+  await safeReply(msg, '@everyone hello');
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].content, '@everyone hello');
+  assert.deepEqual(calls[0].allowedMentions, ALLOWED_MENTIONS_NONE);
+});
+
+test('safeEdit: calls edit() with allowedMentions disabled', async () => {
+  const calls = [];
+  const message = {
+    async edit(o) {
+      calls.push(o);
+      return { id: 'm1' };
+    },
+  };
+
+  await safeEdit(message, '<@123> hi');
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].content, '<@123> hi');
+  assert.deepEqual(calls[0].allowedMentions, ALLOWED_MENTIONS_NONE);
+});
+
+test('ixReplyNoMentions/ixEditReplyNoMentions: force allowedMentions disabled', () => {
+  const r = ixReplyNoMentions({ content: 'x', ephemeral: true, allowedMentions: { parse: ['everyone'] } });
+  assert.deepEqual(r.allowedMentions, ALLOWED_MENTIONS_NONE);
+
+  const e = ixEditReplyNoMentions({ content: 'y', allowedMentions: { parse: ['roles'] } });
+  assert.deepEqual(e.allowedMentions, ALLOWED_MENTIONS_NONE);
+});


### PR DESCRIPTION
Closes #274.\n\nWhat changed:\n- Introduce src/discordMentions.ts helpers that force allowedMentions={parse:[],users:[],roles:[]}.\n- Apply to streaming placeholder reply + edit path, continuation replies, and slash-command interaction replies/edits.\n- Set a global default on the Discord client (ClientOptions.allowedMentions) as defense-in-depth.\n- Document security posture in README (adds the required manual verification steps around @everyone output).\n\nVerification:\n- pnpm test (includes a unit test asserting createDiscordClient() sets allowedMentions disabled)\n- Manual: have OpenCode output @everyone/@here and confirm no ping\n\nRisk: low; the change is limited to documentation + the already-tested helpers.