### PR TITLE
fix: redact sensitive log substrings (#569)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ const FILE_PAUSED = 'pausedChannels.json';
 
 import { buildTopicWithCwd, isMainThreadName, parseCwdFromTopic } from './topic.js';
 import { hintMissingPermissionForSetTopic, runDiscordPreflightOnce } from './permissions.js';
-import { redactSecrets } from './redact.js';
+import { redactForLogs, redactSecrets } from './redact.js';
 import { enqueueThreadWork, DEFAULT_THREAD_QUEUE_LIMIT } from './threadQueue.js';
 
 type LogCtx = {
@@ -75,15 +75,15 @@ function safeErrMeta(e: unknown): { err: string; stack?: string } {
     const anyE = e as any;
     const msg = anyE?.message ? String(anyE.message) : String(e);
     const stack = typeof anyE?.stack === 'string' ? anyE.stack : undefined;
-    const cleanedMsg = cfg.REDACT_SECRETS ? redactSecrets(msg) : msg;
-    const cleanedStack = cfg.REDACT_SECRETS && stack ? redactSecrets(stack) : stack;
+    const cleanedMsg = cfg.REDACT_SECRETS ? redactForLogs(msg) : msg;
+    const cleanedStack = cfg.REDACT_SECRETS && stack ? redactForLogs(stack) : stack;
     return {
       err: cleanedMsg.slice(0, 500),
       stack: cleanedStack ? cleanedStack.slice(0, 1500) : undefined,
     };
   }
   const msg = String(e);
-  const cleaned = cfg.REDACT_SECRETS ? redactSecrets(msg) : msg;
+  const cleaned = cfg.REDACT_SECRETS ? redactForLogs(msg) : msg;
   return { err: cleaned.slice(0, 500) };
 }
 

--- a/src/opencodeAcp.ts
+++ b/src/opencodeAcp.ts
@@ -58,6 +58,7 @@ export class OpenCodeAcpClient {
       }
       console.log(parts.join(' '));
     },
+    private redact: (s: string) => string = (s) => s,
   ) {}
 
   private rememberMeta(meta?: Record<string, unknown>): void {
@@ -101,8 +102,10 @@ export class OpenCodeAcpClient {
         await this.ready;
         return;
       } catch (e) {
-        this.log('acp:ready_failed', this.m({ err: (e as any)?.message ?? String(e) }));
-        this.killProc('ready_failed', this.m({ err: (e as any)?.message ?? String(e) }));
+        const raw = (e as any)?.message ?? String(e);
+        const err = this.redact(String(raw));
+        this.log('acp:ready_failed', this.m({ err }));
+        this.killProc('ready_failed', this.m({ err }));
         this.proc = undefined;
         this.rl?.close();
         this.rl = undefined;
@@ -154,8 +157,10 @@ export class OpenCodeAcpClient {
 
     // Spawn-level error (e.g. binary missing) won't emit 'exit' consistently.
     this.proc.on('error', (e) => {
-      this.log('acp:error', this.m({ err: (e as any)?.message ?? String(e) }));
-      const err = new Error(`opencode acp error: ${(e as any)?.message ?? String(e)}`);
+      const raw = (e as any)?.message ?? String(e);
+      const cleaned = this.redact(String(raw));
+      this.log('acp:error', this.m({ err: cleaned }));
+      const err = new Error(`opencode acp error: ${cleaned}`);
       for (const { reject } of this.pending.values()) reject(err);
       this.pending.clear();
       this.proc = undefined;
@@ -172,7 +177,8 @@ export class OpenCodeAcpClient {
       const s = String(buf).trim();
       if (!s) return;
       const line = s.split(/\r?\n/)[0];
-      this.log('acp:stderr', this.m({ line: line.slice(0, 500) }));
+      const cleaned = this.redact(line);
+      this.log('acp:stderr', this.m({ line: cleaned.slice(0, 500) }));
     });
 
     this.rl = readline.createInterface({ input: this.proc.stdout! });

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -1,4 +1,6 @@
-type Rule = { name: string; re: RegExp; replace: string | ((m: string) => string) };
+import os from 'node:os';
+
+type Rule = { name: string; re: RegExp; replace: string | ((...args: any[]) => string) };
 
 // Keep this intentionally conservative to reduce false-positives.
 const RULES: Rule[] = [
@@ -22,6 +24,18 @@ const RULES: Rule[] = [
   // AWS access key id (do NOT attempt to detect secret access keys; too many false positives)
   { name: 'aws_access_key', re: /\bAKIA[0-9A-Z]{16}\b/g, replace: 'AKIA***REDACTED***' },
 
+  // Generic bearer tokens (common leak pattern)
+  {
+    name: 'bearer',
+    re: /\bBearer\s+[A-Za-z0-9._-]{20,}\b/g,
+    replace: 'Bearer ***REDACTED***',
+  },
+  {
+    name: 'token_kv',
+    re: /\b(access_token|refresh_token|token)=([A-Za-z0-9._-]{20,})\b/g,
+    replace: (_m: string, k: string) => `${k}=***REDACTED***`,
+  },
+
   // PEM private keys (multi-line)
   {
     name: 'pem',
@@ -36,4 +50,33 @@ export function redactSecrets(input: string): string {
     out = out.replace(r.re, r.replace as any);
   }
   return out;
+}
+
+function redactHomeDir(input: string): string {
+  const home = os.homedir();
+  if (!home) return input;
+  // Normalize both plain and URL-encoded-ish variants conservatively.
+  return input.split(home).join('~');
+}
+
+function redactLongAbsPaths(input: string): string {
+  // Only touch very long absolute paths to reduce false positives.
+  // Example: /var/folders/.../T/tmpfile -> /…/tmpfile
+  return input.replace(/\/[\w\-.~/]{60,}/g, (m) => {
+    const s = m.replace(/\s+/g, '');
+    const parts = s.split('/').filter(Boolean);
+    const base = parts.at(-1);
+    if (!base) return '/…';
+    return `/…/${base}`;
+  });
+}
+
+/**
+ * A slightly broader redaction intended for logs. This is still best-effort.
+ * - Masks known secret/token patterns
+ * - Replaces home dir with ~
+ * - Shortens very long absolute paths
+ */
+export function redactForLogs(input: string): string {
+  return redactLongAbsPaths(redactHomeDir(redactSecrets(input)));
 }

--- a/test/redact.test.js
+++ b/test/redact.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+
+import { redactForLogs } from '../dist/redact.js';
+
+test('redactForLogs: replaces home dir with ~', () => {
+  const home = os.homedir();
+  const s = `failed to read ${home}/secret/file.txt`;
+  const out = redactForLogs(s);
+  assert.ok(out.includes('~/secret/file.txt'));
+  assert.ok(!out.includes(home));
+});
+
+test('redactForLogs: redacts known tokens (OpenAI/GitHub/Bearer)', () => {
+  assert.ok(!redactForLogs('sk-abcdefghijklmnopqrstuvwxyz0123456789').includes('abcdefghijklmnopqrstuvwxyz'));
+  assert.equal(redactForLogs('Authorization: Bearer abcdefghijklmnopqrstuvwxyz0123456789'), 'Authorization: Bearer ***REDACTED***');
+  assert.equal(redactForLogs('token=abcdefghijklmnopqrstuvwxyz0123456789'), 'token=***REDACTED***');
+});
+
+test('redactForLogs: shortens very long absolute paths', () => {
+  const long = `/var/folders/xx/yy/zz/${'a'.repeat(80)}/file.log`;
+  const out = redactForLogs(`oops ${long}`);
+  assert.ok(out.includes('/…/file.log'));
+});


### PR DESCRIPTION
Closes #569\n\n- Add redactForLogs(): conservative log redaction (known tokens, Bearer/token=, home dir -> ~, shorten very long absolute paths).\n- Apply to safeErrMeta (when REDACT_SECRETS=true).\n- Apply to ACP stderr + error surfaces via optional redact function on OpenCodeAcpClient (when REDACT_SECRETS=true).\n- Add unit tests (node --test).\n\nVerification:\n- pnpm test\n- Set REDACT_SECRETS=true and trigger an ACP stderr line; confirm home paths become ~ and tokens are masked.