### PR TITLE
fix: ignore non-content messages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ const FILE_PAUSED = 'pausedChannels.json';
 import { buildTopicWithCwd, isMainThreadName, parseCwdFromTopic } from './topic.js';
 import { hintMissingPermissionForSetTopic, runDiscordPreflightOnce } from './permissions.js';
 import { redactSecrets } from './redact.js';
+import { buildPromptTextFromMessage, hasMeaningfulUserText } from './messageFilter.js';
 
 type LogCtx = {
   corr?: string;
@@ -738,6 +739,10 @@ async function main() {
       const roleIds = extractRoleIdsFromMessageMember((m as any).member);
       if (!allowUser(m.author.id, roleIds)) return;
 
+      // Issue #406: ignore non-content messages (stickers/embeds/attachments-only/empty)
+      // and system/webhook messages.
+      if (!hasMeaningfulUserText(m)) return;
+
       const corr = randomUUID().slice(0, 8);
 
       // Ensure we have full channel objects (topics on parents are often missing on partials)
@@ -796,23 +801,9 @@ async function main() {
               // If ACP restarted, ensure the session binding is re-loaded before prompting.
               await oc.ensureSessionLoaded(sessionId, cwd, { ...meta, attempt });
 
-              // Include attachment URLs so prompts like "see screenshot" have context.
-              const attachments = Array.from(m.attachments?.values?.() ?? []);
-              const attachmentText =
-                attachments.length === 0
-                  ? ''
-                  : `\n\n[Attachments]\n${attachments
-                      .map((a) => {
-                        const name = a.name ?? 'file';
-                        const type = (a as any)?.contentType ? String((a as any).contentType) : '';
-                        const size = formatBytes((a as any)?.size);
-                        const meta = [type, size].filter(Boolean).join(', ');
-                        return `- ${name}${meta ? ` (${meta})` : ''}: ${a.url}`;
-                      })
-                      .join('\n')}`;
-              const promptText = `${m.content ?? ''}${attachmentText}`.trim();
+              const promptText = buildPromptTextFromMessage(m);
 
-              // If message has no text and no attachments, do nothing.
+              // Issue #406: By design we only forward when there's meaningful user-authored text.
               if (!promptText) return;
 
               await oc.prompt(sessionId, promptText, emit, { ...meta, attempt });

--- a/src/messageFilter.ts
+++ b/src/messageFilter.ts
@@ -1,0 +1,63 @@
+import type { Message } from 'discord.js';
+
+/**
+ * Issue #406: Only forward meaningful, user-authored text.
+ *
+ * We intentionally ignore messages that are "non-content" from a prompting perspective:
+ * - empty/whitespace-only
+ * - sticker-only / embed-only / attachment-only when content is empty
+ * - system messages
+ * - bot/webhook messages when configured (handled upstream, but supported here too)
+ */
+export function hasMeaningfulUserText(m: Pick<Message, 'content' | 'system' | 'author' | 'webhookId'>): boolean {
+  // Discord system messages (pins, joins, etc.) should never be forwarded.
+  if ((m as any)?.system) return false;
+
+  // Treat webhook messages as non-user authored. (Some may not be bots, but they aren't a human user.)
+  if ((m as any)?.webhookId) return false;
+
+  const content = String((m as any)?.content ?? '').trim();
+  if (!content) return false;
+
+  return true;
+}
+
+function formatBytes(n: any): string {
+  const bytes = typeof n === 'number' && Number.isFinite(n) ? n : null;
+  if (bytes == null) return '';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let v = bytes;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i++;
+  }
+  const rounded = i === 0 ? String(Math.round(v)) : v.toFixed(1).replace(/\.0$/, '');
+  return `${rounded}${units[i]}`;
+}
+
+export function buildPromptTextFromMessage(
+  m: Pick<Message, 'content' | 'attachments'>,
+  opts?: { includeAttachments?: boolean },
+): string {
+  const content = String((m as any)?.content ?? '').trim();
+  if (!content) return '';
+
+  const includeAttachments = opts?.includeAttachments ?? true;
+  if (!includeAttachments) return content;
+
+  const attachments = Array.from((m as any)?.attachments?.values?.() ?? []);
+  if (attachments.length === 0) return content;
+
+  const attachmentText = `\n\n[Attachments]\n${attachments
+    .map((a: any) => {
+      const name = a?.name ?? 'file';
+      const type = a?.contentType ? String(a.contentType) : '';
+      const size = formatBytes(a?.size);
+      const meta = [type, size].filter(Boolean).join(', ');
+      return `- ${name}${meta ? ` (${meta})` : ''}: ${a?.url ?? ''}`.trimEnd();
+    })
+    .join('\n')}`;
+
+  return `${content}${attachmentText}`.trim();
+}

--- a/test/messageFilter.test.js
+++ b/test/messageFilter.test.js
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildPromptTextFromMessage, hasMeaningfulUserText } from '../dist/messageFilter.js';
+
+function fakeCollection(items) {
+  return {
+    values() {
+      return items[Symbol.iterator]();
+    },
+  };
+}
+
+test('hasMeaningfulUserText: accepts non-empty trimmed content', () => {
+  assert.equal(hasMeaningfulUserText({ content: 'hi', system: false, author: { bot: false }, webhookId: null }), true);
+  assert.equal(hasMeaningfulUserText({ content: '  hi  ', system: false, author: { bot: false }, webhookId: null }), true);
+});
+
+test('hasMeaningfulUserText: rejects empty/whitespace-only content', () => {
+  assert.equal(hasMeaningfulUserText({ content: '', system: false, author: { bot: false }, webhookId: null }), false);
+  assert.equal(hasMeaningfulUserText({ content: '   ', system: false, author: { bot: false }, webhookId: null }), false);
+  assert.equal(hasMeaningfulUserText({ content: null, system: false, author: { bot: false }, webhookId: null }), false);
+});
+
+test('hasMeaningfulUserText: rejects system and webhook messages even if they have content', () => {
+  assert.equal(hasMeaningfulUserText({ content: 'hello', system: true, author: { bot: false }, webhookId: null }), false);
+  assert.equal(hasMeaningfulUserText({ content: 'hello', system: false, author: { bot: false }, webhookId: 'wh_1' }), false);
+});
+
+test('buildPromptTextFromMessage: returns empty when content is empty (ignores attachment-only)', () => {
+  const msg = {
+    content: '   ',
+    attachments: fakeCollection([{ name: 'a.png', url: 'https://example.com/a.png', size: 123, contentType: 'image/png' }]),
+  };
+  assert.equal(buildPromptTextFromMessage(msg), '');
+});
+
+test('buildPromptTextFromMessage: includes attachments when content is present', () => {
+  const msg = {
+    content: 'see this',
+    attachments: fakeCollection([
+      { name: 'a.png', url: 'https://example.com/a.png', size: 2048, contentType: 'image/png' },
+    ]),
+  };
+  const out = buildPromptTextFromMessage(msg);
+  assert.ok(out.startsWith('see this'));
+  assert.ok(out.includes('[Attachments]'));
+  assert.ok(out.includes('a.png'));
+  assert.ok(out.includes('https://example.com/a.png'));
+});


### PR DESCRIPTION
Fixes #406.\n\n- Only forward meaningful user-authored text (ignore empty/whitespace-only).\n- Ignore system/webhook messages.\n- Do not forward sticker-only/embed-only/attachment-only messages when content is empty.\n- Keep attachment URLs appended when content exists.\n\nTests: added unit tests for the new predicate + prompt builder.