### PR TITLE
Fix: show safe prompt failure message (corr id)

### DIFF
--- a/src/discord.ts
+++ b/src/discord.ts
@@ -11,6 +11,7 @@ import {
   TextChannel,
   ThreadChannel,
 } from 'discord.js';
+import type { Message } from 'discord.js';
 import type { Config } from './config.js';
 
 export type SlashHandlers = {
@@ -92,4 +93,133 @@ export async function handleInteraction(ix: Interaction, handlers: SlashHandlers
   if (sub === 'pause') return handlers.pause(ix);
   if (sub === 'resume') return handlers.resume(ix);
   if (sub === 'cwd') return handlers.cwdSet(ix);
+}
+
+export type StreamToDiscordOptions = {
+  /** Correlation id shown to the user on failure. */
+  corr?: string;
+  /**
+   * Additional metadata passed through to withDiscordRetry for logging.
+   * Should be small and free of secrets.
+   */
+  meta?: Record<string, any>;
+  /**
+   * If provided, all Discord writes go through this wrapper.
+   * (Bridge uses it for rate-limit/network retries.)
+   */
+  withDiscordRetry?: <T>(op: () => Promise<T>, meta: Record<string, any>) => Promise<T>;
+  /** Apply output redaction (if enabled) before writing to Discord. */
+  redactSecrets?: boolean;
+  /** Redaction function used when redactSecrets=true. */
+  redact?: (input: string) => string;
+};
+
+function formatPromptFailureMessage(corr?: string): string {
+  const id = typeof corr === 'string' ? corr.trim().slice(0, 32) : '';
+  const corrPart = id ? ` (corr=${id})` : '';
+  // Keep it generic: no stack traces, no exception messages, no config paths.
+  return (
+    `Sorry — the bridge hit an internal error while processing your prompt${corrPart}.\n` +
+    `Please try again. If this keeps happening, ask an admin to check the bridge logs using the correlation id.`
+  );
+}
+
+export async function streamToDiscord(
+  msg: Message,
+  onChunk: (cb: (t: string) => void) => Promise<void>,
+  opts: StreamToDiscordOptions = {},
+): Promise<void> {
+  const baseMeta = opts.meta ?? {};
+  const corr = opts.corr ?? (typeof (baseMeta as any).corr === 'string' ? String((baseMeta as any).corr) : undefined);
+
+  const withRetry =
+    opts.withDiscordRetry ??
+    (async <T>(op: () => Promise<T>) => {
+      return op();
+    });
+
+  const placeholder = await withRetry(() => msg.reply('…'), { ...baseMeta, phase: 'reply_placeholder' });
+
+  let text = '';
+  let lastEdit = 0;
+  let failed = false;
+
+  // Serialize Discord writes for this stream to avoid overlapping edits/replies under burst.
+  let q: Promise<void> = Promise.resolve();
+  const serial = (fn: () => Promise<void>) => {
+    q = q.then(fn, fn);
+    return q;
+  };
+
+  let scheduled: NodeJS.Timeout | null = null;
+  const scheduleFlush = (force = false) => {
+    if (failed) return;
+    if (force) return void flush(true);
+    if (scheduled) return;
+    scheduled = setTimeout(() => {
+      scheduled = null;
+      void flush(false);
+    }, 1200);
+  };
+
+  const flush = async (force = false) => {
+    if (failed) return;
+    const now = Date.now();
+    if (!force && now - lastEdit < 1100) return;
+    lastEdit = now;
+
+    const safeText = opts.redactSecrets && opts.redact ? opts.redact(text) : text;
+
+    await serial(async () => {
+      if (safeText.length <= 2000) {
+        await withRetry(() => (placeholder as any).edit(safeText || ''), { ...baseMeta, phase: 'edit_placeholder' });
+        return;
+      }
+
+      // If too long, finalize current message and continue in new replies.
+      // Keep the placeholder capped at 2000.
+      const head = safeText.slice(0, 2000);
+      await withRetry(() => (placeholder as any).edit(head), { ...baseMeta, phase: 'edit_placeholder_head' });
+      let rest = safeText.slice(2000);
+      while (rest.length > 0) {
+        const part = rest.slice(0, 2000);
+        // eslint-disable-next-line no-await-in-loop
+        await withRetry(() => msg.reply(part), { ...baseMeta, phase: 'reply_continuation' });
+        rest = rest.slice(2000);
+      }
+    });
+  };
+
+  try {
+    await onChunk((t) => {
+      text += t;
+      scheduleFlush(false);
+    });
+
+    await flush(true);
+  } catch (e) {
+    failed = true;
+    if (scheduled) {
+      clearTimeout(scheduled);
+      scheduled = null;
+    }
+
+    // Best-effort: overwrite the placeholder so the user isn't left with "…".
+    // Do not include exception details (may contain secrets).
+    // Use the same serial queue so the error message "wins" over any in-flight flush edits.
+    try {
+      await serial(async () => {
+        await withRetry(
+          () => (placeholder as any).edit(formatPromptFailureMessage(corr)),
+          { ...baseMeta, phase: 'edit_placeholder_error' },
+        );
+      });
+    } catch {
+      // ignore: original error will be logged upstream
+    }
+
+    throw e;
+  } finally {
+    if (scheduled) clearTimeout(scheduled);
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import {
   handleInteraction,
   isInScopeGuild,
   registerSlashCommands,
+  streamToDiscord,
 } from './discord.js';
 import {
   extractRoleIdsFromInteractionMember,
@@ -453,65 +454,7 @@ async function withDiscordRetry<T>(
   throw lastErr;
 }
 
-async function streamToDiscord(
-  msg: Message,
-  onChunk: (cb: (t: string) => void) => Promise<void>,
-): Promise<void> {
-  const placeholder = await withDiscordRetry(() => msg.reply('…'), { phase: 'reply_placeholder' });
-  let text = '';
-  let lastEdit = 0;
-
-  // Serialize Discord writes for this stream to avoid overlapping edits/replies under burst.
-  let q: Promise<void> = Promise.resolve();
-  const serial = (fn: () => Promise<void>) => {
-    q = q.then(fn, fn);
-    return q;
-  };
-
-  let scheduled: NodeJS.Timeout | null = null;
-  const scheduleFlush = (force = false) => {
-    if (force) return void flush(true);
-    if (scheduled) return;
-    scheduled = setTimeout(() => {
-      scheduled = null;
-      void flush(false);
-    }, 1200);
-  };
-
-  const flush = async (force = false) => {
-    const now = Date.now();
-    if (!force && now - lastEdit < 1100) return;
-    lastEdit = now;
-
-    const safeText = cfg.REDACT_SECRETS ? redactSecrets(text) : text;
-
-    await serial(async () => {
-      if (safeText.length <= 2000) {
-        await withDiscordRetry(() => placeholder.edit(safeText || ''), { phase: 'edit_placeholder' });
-        return;
-      }
-
-      // If too long, finalize current message and continue in new replies.
-      // Keep the placeholder capped at 2000.
-      const head = safeText.slice(0, 2000);
-      await withDiscordRetry(() => placeholder.edit(head), { phase: 'edit_placeholder_head' });
-      let rest = safeText.slice(2000);
-      while (rest.length > 0) {
-        const part = rest.slice(0, 2000);
-        // eslint-disable-next-line no-await-in-loop
-        await withDiscordRetry(() => msg.reply(part), { phase: 'reply_continuation' });
-        rest = rest.slice(2000);
-      }
-    });
-  };
-
-  await onChunk((t) => {
-    text += t;
-    scheduleFlush(false);
-  });
-  await flush(true);
-  if (scheduled) clearTimeout(scheduled);
-}
+// streamToDiscord moved to src/discord.ts
 
 const THREAD_BACKPRESSURE_MESSAGE =
   'Bridge is still replying to earlier prompts in this thread. Please wait a moment before sending more.';
@@ -820,55 +763,71 @@ async function main() {
             messageId: m.id,
           });
 
-          await streamToDiscord(m, async (emit) => {
-            const meta = {
-              corr,
-              threadId: thread.id,
-              channelId,
-              messageId: m.id,
-              sessionId,
-            };
+          await streamToDiscord(
+            m,
+            async (emit) => {
+              const meta = {
+                corr,
+                threadId: thread.id,
+                channelId,
+                messageId: m.id,
+                sessionId,
+              };
 
-            await retryWithBackoff(
-              async (attempt) => {
-                if (attempt > 1) {
-                  logInfo('prompt:retry', { ...meta, attempt });
-                }
-                try {
-                  await oc.ensureSessionLoaded(sessionId, cwd, { ...meta, attempt });
+              await retryWithBackoff(
+                async (attempt) => {
+                  if (attempt > 1) {
+                    logInfo('prompt:retry', { ...meta, attempt });
+                  }
+                  try {
+                    await oc.ensureSessionLoaded(sessionId, cwd, { ...meta, attempt });
 
-                  const attachments = Array.from(m.attachments?.values?.() ?? []);
-                  const attachmentText =
-                    attachments.length === 0
-                      ? ''
-                      : `\n\n[Attachments]\n${attachments
-                          .map((a) => {
-                            const name = a.name ?? 'file';
-                            const type = (a as any)?.contentType ? String((a as any).contentType) : '';
-                            const size = formatBytes((a as any)?.size);
-                            const meta = [type, size].filter(Boolean).join(', ');
-                            return `- ${name}${meta ? ` (${meta})` : ''}: ${a.url}`;
-                          })
-                          .join('\n')}`;
-                  const promptText = `${m.content ?? ''}${attachmentText}`.trim();
+                    const attachments = Array.from(m.attachments?.values?.() ?? []);
+                    const attachmentText =
+                      attachments.length === 0
+                        ? ''
+                        : `\n\n[Attachments]\n${attachments
+                            .map((a) => {
+                              const name = a.name ?? 'file';
+                              const type = (a as any)?.contentType ? String((a as any).contentType) : '';
+                              const size = formatBytes((a as any)?.size);
+                              const meta = [type, size].filter(Boolean).join(', ');
+                              return `- ${name}${meta ? ` (${meta})` : ''}: ${a.url}`;
+                            })
+                            .join('\n')}`;
+                    const promptText = `${m.content ?? ''}${attachmentText}`.trim();
 
-                  if (!promptText) return;
+                    if (!promptText) return;
 
-                  await oc.prompt(sessionId, promptText, emit, { ...meta, attempt });
-                } catch (e) {
-                  logError('prompt:attempt_failed', { ...meta, e });
-                  throw e;
-                }
-              },
-              {
-                attempts: 3,
-                baseDelayMs: 300,
-                onRetry: ({ attempt, delayMs, err }) => {
-                  logError('prompt:retry_scheduled', { ...meta, attempt, delayMs, e: err });
+                    await oc.prompt(sessionId, promptText, emit, { ...meta, attempt });
+                  } catch (e) {
+                    logError('prompt:attempt_failed', { ...meta, e });
+                    throw e;
+                  }
                 },
+                {
+                  attempts: 3,
+                  baseDelayMs: 300,
+                  onRetry: ({ attempt, delayMs, err }) => {
+                    logError('prompt:retry_scheduled', { ...meta, attempt, delayMs, e: err });
+                  },
+                },
+              );
+            },
+            {
+              corr,
+              meta: {
+                corr,
+                threadId: thread.id,
+                channelId,
+                messageId: m.id,
+                sessionId,
               },
-            );
-          });
+              withDiscordRetry,
+              redactSecrets: cfg.REDACT_SECRETS,
+              redact: redactSecrets,
+            },
+          );
 
           const now = Date.now();
           await setThreadBinding(thread.id, { ...ensured.binding, updatedAt: now });

--- a/test/discordStream.test.js
+++ b/test/discordStream.test.js
@@ -1,0 +1,94 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { streamToDiscord } from '../dist/discord.js';
+
+test('streamToDiscord: edits placeholder with safe error (includes corr) when onChunk throws', async () => {
+  const replies = [];
+  const edits = [];
+
+  const placeholder = {
+    edit: async (t) => {
+      edits.push(t);
+    },
+  };
+
+  const msg = {
+    reply: async (t) => {
+      replies.push(t);
+      return placeholder;
+    },
+  };
+
+  await assert.rejects(
+    () =>
+      streamToDiscord(
+        msg,
+        async (emit) => {
+          emit('partial');
+          throw new Error('boom: secrets=123');
+        },
+        { corr: 'abc12345' },
+      ),
+    /boom/, // the internal error still propagates upstream
+  );
+
+  assert.equal(replies[0], '…');
+  assert.ok(edits.length >= 1, 'placeholder should be edited on failure');
+  const last = edits.at(-1);
+  assert.ok(last.includes('corr=abc12345'));
+  assert.ok(!last.includes('boom'), 'user-facing error must not include exception details');
+  assert.ok(!last.includes('secrets=123'), 'user-facing error must not leak exception payloads');
+});
+
+test('streamToDiscord: streams and flushes final text', async () => {
+  const edits = [];
+  const placeholder = {
+    edit: async (t) => {
+      edits.push(t);
+    },
+  };
+
+  const msg = {
+    reply: async () => placeholder,
+  };
+
+  await streamToDiscord(msg, async (emit) => {
+    emit('hello');
+    emit(' world');
+  });
+
+  assert.equal(edits.at(-1), 'hello world');
+});
+
+test('streamToDiscord: splits >2000 chars into continuation replies', async () => {
+  const replies = [];
+  const edits = [];
+  const placeholder = {
+    edit: async (t) => {
+      edits.push(t);
+    },
+  };
+
+  const msg = {
+    reply: async (t) => {
+      replies.push(t);
+      return placeholder;
+    },
+  };
+
+  const s = 'a'.repeat(4500);
+  await streamToDiscord(msg, async (emit) => {
+    emit(s);
+  });
+
+  // First reply is placeholder.
+  assert.equal(replies[0], '…');
+  // Placeholder edited to head(2000).
+  assert.equal(edits[0].length, 2000);
+
+  // Continuations: remaining 2500 => 2 replies (2000 + 500)
+  const continuations = replies.slice(1);
+  assert.equal(continuations.length, 2);
+  assert.equal(continuations[0].length, 2000);
+  assert.equal(continuations[1].length, 500);
+});


### PR DESCRIPTION
Fixes #565.

When OpenCode prompt streaming fails after retries, the bridge now edits the Discord placeholder reply to a generic, secret-free error that includes the correlation id (corr=...).

- Moves streamToDiscord into discord module so it can be unit-tested.
- Ensures error placeholder edit is serialized so it wins over any in-flight flush edits.
- Adds unit tests covering failure/success/splitting behavior.

Verification:
- pnpm test