### PR TITLE
Security: disable mention parsing for bridged messages (fix #221)

### DIFF
--- a/src/bridgeAllowedMentions.ts
+++ b/src/bridgeAllowedMentions.ts
@@ -1,0 +1,21 @@
+import type { MessageMentionOptions } from 'discord.js';
+
+/**
+ * Security hardening: bridged content must never produce pings.
+ *
+ * Discord defaults to parsing mentions in message content. For bridge output, we
+ * always disable mention parsing so untrusted text cannot ping @everyone/@here,
+ * roles, or users.
+ */
+export const BRIDGE_ALLOWED_MENTIONS: MessageMentionOptions = {
+  parse: [],
+};
+
+export function bridgeMessageOptions<T extends Record<string, any>>(
+  opts: T,
+): Omit<T, 'allowedMentions'> & { allowedMentions: MessageMentionOptions } {
+  return {
+    ...(opts as any),
+    allowedMentions: BRIDGE_ALLOWED_MENTIONS,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import {
 } from './auth.js';
 import { formatCwdValidationError, validateChannelCwd } from './cwd.js';
 import type { ChatInputCommandInteraction, Message, TextChannel, ThreadChannel } from 'discord.js';
+import { bridgeMessageOptions } from './bridgeAllowedMentions.js';
 
 const cfg = loadConfig(process.env);
 
@@ -430,7 +431,10 @@ async function streamToDiscord(
   msg: Message,
   onChunk: (cb: (t: string) => void) => Promise<void>,
 ): Promise<void> {
-  const placeholder = await withDiscordRetry(() => msg.reply('…'), { phase: 'reply_placeholder' });
+  const placeholder = await withDiscordRetry(
+    () => msg.reply(bridgeMessageOptions({ content: '…' })),
+    { phase: 'reply_placeholder' },
+  );
   let text = '';
   let lastEdit = 0;
 
@@ -460,19 +464,28 @@ async function streamToDiscord(
 
     await serial(async () => {
       if (safeText.length <= 2000) {
-        await withDiscordRetry(() => placeholder.edit(safeText || ''), { phase: 'edit_placeholder' });
+        await withDiscordRetry(
+          () => placeholder.edit(bridgeMessageOptions({ content: safeText || '' })),
+          { phase: 'edit_placeholder' },
+        );
         return;
       }
 
       // If too long, finalize current message and continue in new replies.
       // Keep the placeholder capped at 2000.
       const head = safeText.slice(0, 2000);
-      await withDiscordRetry(() => placeholder.edit(head), { phase: 'edit_placeholder_head' });
+      await withDiscordRetry(
+        () => placeholder.edit(bridgeMessageOptions({ content: head })),
+        { phase: 'edit_placeholder_head' },
+      );
       let rest = safeText.slice(2000);
       while (rest.length > 0) {
         const part = rest.slice(0, 2000);
         // eslint-disable-next-line no-await-in-loop
-        await withDiscordRetry(() => msg.reply(part), { phase: 'reply_continuation' });
+        await withDiscordRetry(
+          () => msg.reply(bridgeMessageOptions({ content: part })),
+          { phase: 'reply_continuation' },
+        );
         rest = rest.slice(2000);
       }
     });

--- a/test/allowed-mentions.test.js
+++ b/test/allowed-mentions.test.js
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { BRIDGE_ALLOWED_MENTIONS, bridgeMessageOptions } from '../dist/bridgeAllowedMentions.js';
+
+test('bridgeMessageOptions: forces allowedMentions.parse=[]', () => {
+  assert.deepEqual(BRIDGE_ALLOWED_MENTIONS, { parse: [] });
+
+  const opts = bridgeMessageOptions({ content: 'hi @everyone <@123> <@&456>' });
+  assert.equal(opts.content, 'hi @everyone <@123> <@&456>');
+  assert.deepEqual(opts.allowedMentions, { parse: [] });
+});
+
+test('bridgeMessageOptions: overrides any caller-provided allowedMentions', () => {
+  const opts = bridgeMessageOptions({ content: 'x', allowedMentions: { parse: ['users', 'roles', 'everyone'] } });
+  assert.deepEqual(opts.allowedMentions, { parse: [] });
+});


### PR DESCRIPTION
Mentions hardening: ensure bridged messages cannot trigger Discord mentions.

- Adds bridgeAllowedMentions helper
- Adds unit tests

Fixes #221.